### PR TITLE
json decode as assoc array

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -66,6 +66,6 @@ class Client
 
         $body = (string)$response->getBody();
 
-        return $withJson ? json_decode($body) : $body;
+        return $withJson ? json_decode($body, true) : $body;
     }
 }


### PR DESCRIPTION
En la méthode `json()` de guzzle 5 retournait un tableau associatif.